### PR TITLE
fix: update vendorHash and add Nix CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,47 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           AUR_KEY: ${{ env.AUR_KEY_PATH }}
+
+  nix:
+    name: Nix
+    needs: release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Verify or update vendorHash
+        run: |
+          set +e
+          output=$(nix build .#grove 2>&1)
+          rc=$?
+          set -e
+
+          if [ $rc -eq 0 ]; then
+            echo "vendorHash is up to date"
+            exit 0
+          fi
+
+          new_hash=$(echo "$output" | grep "got:" | awk '{print $2}')
+          if [ -z "$new_hash" ]; then
+            echo "::error::Nix build failed but could not extract new hash"
+            echo "$output"
+            exit 1
+          fi
+
+          echo "Updating vendorHash to $new_hash"
+          sed -i "s|vendorHash = \".*\"|vendorHash = \"$new_hash\"|" flake.nix
+
+          # Verify the build succeeds with the new hash
+          nix build .#grove
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit -m "chore: update vendorHash for v$(cat VERSION)"
+          git push

--- a/docs/adr/ADR-008-release-pipeline-structure.md
+++ b/docs/adr/ADR-008-release-pipeline-structure.md
@@ -1,0 +1,39 @@
+# ADR-008: Release pipeline structure
+
+**Status:** Accepted
+**Date:** 2026-04-29
+**Applies to:** `.github/workflows/ci.yml`, `flake.nix`
+
+## Context
+
+All Go TUI projects (grove, canopy, paperflow) share the same release toolchain: GoReleaser for binaries + Homebrew + AUR, and a Nix flake for NixOS/home-manager consumers. The Nix flake uses `buildGoModule` which requires a `vendorHash` — a SHA256 of the Go module dependencies. This hash changes whenever `go.mod`/`go.sum` change and must be updated manually, which broke the Nix build after the v0.8.0 release.
+
+A monolithic release job also meant that a Nix build failure could block or complicate the binary release, and vice versa.
+
+## Decision
+
+The CI pipeline is structured as three sequential jobs:
+
+1. **Check** — runs on every push to `dev` and on PRs to `main`. Build, vet, gofmt, golangci-lint, and race-detected tests.
+2. **Release** — runs after Check passes, on PRs (snapshot only) and on main push (auto-tag + GoReleaser). Produces binaries, GitHub Release, Homebrew tap update, and AUR package.
+3. **Nix** — runs after Release succeeds, only on main push. Verifies the Nix flake builds. If `vendorHash` is stale, computes the correct hash from the build error, updates `flake.nix`, and pushes the fix automatically.
+
+All three projects (grove, canopy, paperflow) use this same structure. The `release.yml` fallback workflow (triggered by manual tag push) is removed — `ci.yml` handles everything.
+
+## Alternatives Considered
+
+**Monolithic release job with inline Nix step**: simpler YAML, but Nix installation adds ~60s to every release even when the hash hasn't changed. A failure in vendorHash computation blocks the binary release. Rejected because distribution channels should be independent.
+
+**Committed vendor/ directory with `vendorHash = null`**: eliminates the hash problem entirely, but adds significant repo bloat for projects with many transitive dependencies. Rejected for cleanliness.
+
+**gomod2nix**: generates a `gomod2nix.toml` mapping file instead of a single hash. More precise but adds a flake input dependency and changes the build mechanism from `buildGoModule` to `buildGoApplication`. Rejected as overkill for single-binary projects.
+
+**Pre-commit hook to update vendorHash**: requires Nix installed on developer machines and runs on every commit. Rejected as too invasive for contributors without Nix.
+
+## Consequences
+
+- Binary releases (GitHub, Homebrew, AUR) are never blocked by Nix issues.
+- Nix consumers get a working `vendorHash` within minutes of a release, automatically.
+- The pipeline is identical across all Go projects, reducing maintenance.
+- CI requires the `DeterminateSystems/nix-installer-action` in the Nix job, adding ~30s of setup time.
+- If the Nix job fails for reasons other than vendorHash (e.g., nixpkgs breakage), it surfaces as a separate failure that doesn't affect the release.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,4 @@
 | [ADR-005](ADR-005-dynamic-column-widths.md) | Dynamic column widths | ui |
 | [ADR-006](ADR-006-multi-forge-provider-abstraction.md) | Multi-forge provider abstraction | model, gh, config, app, clone |
 | [ADR-007](ADR-007-television-sesh-integration.md) | Television and sesh integration | app, commands |
+| [ADR-008](ADR-008-release-pipeline-structure.md) | Release pipeline structure | CI, Nix |

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
             # Update when go.mod changes:
             #   nix build .# 2>&1 | grep "got:" | awk '{print $2}'
-            vendorHash = "sha256-Ea94DPGLBQhW3gILQlWQXVVSZzJxGVtr0vuzYZSSUsk=";
+            vendorHash = "sha256-H3UWahntqhEIhYvaX9JyUe27lraVDeh5zUzE2tLs28o=";
 
             subPackages = [ "cmd/grove" ];
             ldflags = [ "-s" "-w" "-X main.version=${version}" ];


### PR DESCRIPTION
## Summary
- Fix vendorHash in flake.nix for v0.8.0 go.mod changes (immediate build fix)
- Add separate Nix CI job that auto-updates vendorHash after each release
- Nix job runs after Release succeeds, so Homebrew/AUR aren't blocked

## Pipeline structure
1. **Check** — build, vet, lint, test
2. **Release** — snapshot, auto-tag, GoReleaser (binaries, Homebrew, AUR)
3. **Nix** — verify/update vendorHash (only on main push, after Release)

## Test plan
- [x] `nix build .#grove` succeeds with new vendorHash
- [ ] CI passes on PR