### PR TITLE
fix: route auth errors by forge provider

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -75,6 +75,18 @@ func providerForRemote(providers map[string]forge.Provider, remote config.Remote
 	return providers[remote.Key()]
 }
 
+func remoteLabel(remote config.Remote) string {
+	forgeName := remote.EffectiveForge()
+	if forgeName == "forgejo" && remote.InstanceURL != "" {
+		return forgeName + " " + remote.InstanceURL
+	}
+	return forgeName
+}
+
+func formatRemoteError(repoName string, remote config.Remote, err error) string {
+	return fmt.Sprintf("%s [%s]: %v", repoName, remoteLabel(remote), err)
+}
+
 func loadRepos(profiles []config.Profile) tea.Cmd {
 	return func() tea.Msg {
 		// Collect all (path, profile) pairs, deduplicated by path.
@@ -148,7 +160,7 @@ func loadPRs(profiles []config.Profile, providers map[string]forge.Provider) tea
 					prs, err := prov.ListPRs(repoFull)
 					mu.Lock()
 					if err != nil {
-						errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+						errs = append(errs, formatRemoteError(name, remote, err))
 					} else {
 						localRepoFull := remote.Owner + "/" + name
 						for i := range prs {
@@ -196,7 +208,7 @@ func loadBranches(profiles []config.Profile, providers map[string]forge.Provider
 					branches, err := prov.ListBranches(repoFull)
 					if err != nil {
 						mu.Lock()
-						errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+						errs = append(errs, formatRemoteError(name, remote, err))
 						mu.Unlock()
 						return
 					}
@@ -321,7 +333,7 @@ func loadRuns(profiles []config.Profile, providers map[string]forge.Provider) te
 					runs, err := prov.ListWorkflowRuns(repoFull)
 					mu.Lock()
 					if err != nil {
-						errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+						errs = append(errs, formatRemoteError(name, remote, err))
 					} else {
 						localRepoFull := remote.Owner + "/" + name
 						for i := range runs {
@@ -369,7 +381,7 @@ func loadIssues(profiles []config.Profile, providers map[string]forge.Provider) 
 					issues, err := prov.ListIssues(repoFull)
 					mu.Lock()
 					if err != nil {
-						errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+						errs = append(errs, formatRemoteError(name, remote, err))
 					} else {
 						localRepoFull := remote.Owner + "/" + name
 						for i := range issues {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -120,9 +120,9 @@ type Model struct {
 	issuesLoadedAt   time.Time
 
 	// Load errors — shown in view when a tab has no data
-	errLog  []string
-	authErr bool   // true when any gh call returned ErrNotLoggedIn
-	logPath string // path of the runtime log file, shown in the help bar
+	errLog   []string
+	authKind string // "", "github", "forgejo", or "mixed"
+	logPath  string // path of the runtime log file, shown in the help bar
 
 	// Filter
 	filtering   bool

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -19,15 +19,49 @@ func (m Model) saveState() {
 	_ = cache.SaveState(m.cacheDir, cache.UIState{ActiveProfile: m.activeProfile})
 }
 
-// containsAuthErr returns true if any error string matches the auth sentinel.
-func containsAuthErr(errs []string) bool {
+// authErrorKind returns the provider family for auth failures in a load result.
+func authErrorKind(errs []string) string {
 	needle := forge.ErrNotAuthenticated.Error()
+	hasGitHub := false
+	hasForgejo := false
+	hasUnknown := false
 	for _, e := range errs {
-		if strings.Contains(e, needle) {
-			return true
+		if !strings.Contains(e, needle) {
+			continue
+		}
+		lower := strings.ToLower(e)
+		switch {
+		case strings.Contains(lower, "[github]") || strings.Contains(lower, "github"):
+			hasGitHub = true
+		case strings.Contains(lower, "[forgejo") || strings.Contains(lower, "forgejo"):
+			hasForgejo = true
+		default:
+			hasUnknown = true
 		}
 	}
-	return false
+	kinds := 0
+	if hasGitHub {
+		kinds++
+	}
+	if hasForgejo {
+		kinds++
+	}
+	if hasUnknown {
+		kinds++
+	}
+	if kinds > 1 {
+		return "mixed"
+	}
+	if hasGitHub {
+		return "github"
+	}
+	if hasForgejo {
+		return "forgejo"
+	}
+	if hasUnknown {
+		return "unknown"
+	}
+	return ""
 }
 
 func (m Model) Init() tea.Cmd {
@@ -136,7 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case prsLoadedMsg:
 		m.prs = msg.prs
 		m.errLog = msg.errors
-		m.authErr = containsAuthErr(msg.errors)
+		m.authKind = authErrorKind(msg.errors)
 		m.prsLoadedAt = time.Now()
 		m.loading = false
 		if len(msg.errors) > 0 {
@@ -149,7 +183,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case branchesLoadedMsg:
 		m.branches = msg.branches
 		m.errLog = msg.errors
-		m.authErr = containsAuthErr(msg.errors)
+		m.authKind = authErrorKind(msg.errors)
 		m.branchesLoadedAt = time.Now()
 		m.loading = false
 		if len(msg.errors) > 0 {
@@ -169,7 +203,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case runsLoadedMsg:
 		m.runs = msg.runs
 		m.errLog = msg.errors
-		m.authErr = containsAuthErr(msg.errors)
+		m.authKind = authErrorKind(msg.errors)
 		m.runsLoadedAt = time.Now()
 		m.loading = false
 		if len(msg.errors) > 0 {
@@ -182,7 +216,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case issuesLoadedMsg:
 		m.issues = msg.issues
 		m.errLog = msg.errors
-		m.authErr = containsAuthErr(msg.errors)
+		m.authKind = authErrorKind(msg.errors)
 		m.issuesLoadedAt = time.Now()
 		m.loading = false
 		if len(msg.errors) > 0 {

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -320,6 +320,44 @@ func TestUpdateBranchesLoadedWithErrors(t *testing.T) {
 	}
 }
 
+func TestAuthErrorKind(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []string
+		want string
+	}{
+		{
+			name: "github",
+			errs: []string{"repo [github]: not authenticated: run gh auth login"},
+			want: "github",
+		},
+		{
+			name: "forgejo",
+			errs: []string{"repo [forgejo https://git.alc.xyz]: not authenticated: https://git.alc.xyz returned 401"},
+			want: "forgejo",
+		},
+		{
+			name: "mixed",
+			errs: []string{
+				"repo-a [github]: not authenticated: run gh auth login",
+				"repo-b [forgejo https://git.alc.xyz]: not authenticated: https://git.alc.xyz returned 401",
+			},
+			want: "mixed",
+		},
+		{
+			name: "none",
+			errs: []string{"repo: connection refused"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := authErrorKind(tt.errs); got != tt.want {
+			t.Errorf("%s: authErrorKind() = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 // ── Window resize ───────────────────────────────────────────────────────
 
 func TestUpdateWindowResize(t *testing.T) {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -308,8 +308,8 @@ func (m Model) View() string {
 			}
 			b.WriteString(ui.RenderDashboard(m.groupedRepos(), m.cursor, cw, so, sh, prCounts, branchCounts, issueCounts, ciStatus, hlField, hlValue))
 		case tabPRs:
-			if m.authErr {
-				b.WriteString(ui.RenderAuthError())
+			if m.authKind != "" && len(m.prs) == 0 {
+				b.WriteString(ui.RenderAuthError(m.authKind, m.errLog))
 			} else {
 				b.WriteString(ui.RenderPRs(m.groupedPRs(), m.cursor, cw, so, sh, hlField, hlValue))
 				if len(m.prs) == 0 && len(m.errLog) > 0 {
@@ -317,8 +317,8 @@ func (m Model) View() string {
 				}
 			}
 		case tabBranches:
-			if m.authErr {
-				b.WriteString(ui.RenderAuthError())
+			if m.authKind != "" && len(m.branches) == 0 {
+				b.WriteString(ui.RenderAuthError(m.authKind, m.errLog))
 			} else {
 				prBranches := map[string]bool{}
 				for _, pr := range m.prs {
@@ -332,8 +332,8 @@ func (m Model) View() string {
 		case tabActivity:
 			b.WriteString(ui.RenderActivity(m.groupedActivity(), m.cursor, cw, so, sh, hlField, hlValue))
 		case tabCI:
-			if m.authErr {
-				b.WriteString(ui.RenderAuthError())
+			if m.authKind != "" && len(m.runs) == 0 {
+				b.WriteString(ui.RenderAuthError(m.authKind, m.errLog))
 			} else {
 				b.WriteString(ui.RenderCI(m.groupedRuns(), m.cursor, cw, so, sh, hlField, hlValue))
 				if len(m.runs) == 0 && len(m.errLog) > 0 {
@@ -341,8 +341,8 @@ func (m Model) View() string {
 				}
 			}
 		case tabIssues:
-			if m.authErr {
-				b.WriteString(ui.RenderAuthError())
+			if m.authKind != "" && len(m.issues) == 0 {
+				b.WriteString(ui.RenderAuthError(m.authKind, m.errLog))
 			} else {
 				b.WriteString(ui.RenderIssues(m.groupedIssues(), m.cursor, cw, so, sh, hlField, hlValue))
 				if len(m.issues) == 0 && len(m.errLog) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,7 +366,7 @@ func (r Remote) Key() string {
 	return strings.Join([]string{
 		r.Owner,
 		r.Repo,
-		r.Forge,
+		r.EffectiveForge(),
 		r.InstanceURL,
 		r.TokenFile,
 		r.CloneProto,
@@ -403,6 +403,12 @@ func mergeRemote(base, override Remote) Remote {
 		base.Repo = override.Repo
 	}
 	if override.Forge != "" {
+		if base.EffectiveForge() != override.EffectiveForge() {
+			base.InstanceURL = ""
+			base.TokenFile = ""
+			base.CloneProto = ""
+			base.SSHHost = ""
+		}
 		base.Forge = override.Forge
 	}
 	if override.InstanceURL != "" {
@@ -511,6 +517,11 @@ func (c Config) AllRemotes() []Remote {
 		add(p.CodeRemote("", ""))
 		add(p.SocialRemote("", ""))
 		add(p.CIRemote("", ""))
+		for _, g := range p.ResolveGroups() {
+			add(mergeRemote(p.codeDefaults(), g.Code))
+			add(mergeRemote(mergeRemote(p.codeDefaults(), p.Social), g.Social))
+			add(mergeRemote(mergeRemote(p.codeDefaults(), p.CI), g.CI))
+		}
 		for _, ov := range p.Repos {
 			add(p.CodeRemote(ov.Name, ""))
 			add(p.SocialRemote(ov.Name, ""))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -348,6 +348,62 @@ func TestProfileGroupRemoteResolution(t *testing.T) {
 	}
 }
 
+func TestAllRemotesIncludesGroupOverrides(t *testing.T) {
+	c := Config{Profiles: []Profile{{
+		Name:        "alcxyz",
+		Owner:       "alcxyz",
+		Forge:       "forgejo",
+		InstanceURL: "https://git.alc.xyz",
+		TokenFile:   "/tmp/forgejo-token",
+		Groups: []Group{{
+			Name:      "forks",
+			MatchPath: "/home/user/src/forks",
+			Social: Remote{
+				Owner: "alcxyz",
+				Forge: "github",
+			},
+			CI: Remote{
+				Owner: "alcxyz",
+				Forge: "github",
+			},
+		}},
+	}}}
+
+	seen := map[string]Remote{}
+	for _, r := range c.AllRemotes() {
+		seen[r.Key()] = r
+	}
+
+	groupSocial := mergeRemote(mergeRemote(c.Profiles[0].codeDefaults(), c.Profiles[0].Social), c.Profiles[0].Groups[0].Social)
+	if _, ok := seen[groupSocial.Key()]; !ok {
+		t.Fatalf("group social remote was not included in AllRemotes: %+v", groupSocial)
+	}
+
+	groupCI := mergeRemote(mergeRemote(c.Profiles[0].codeDefaults(), c.Profiles[0].CI), c.Profiles[0].Groups[0].CI)
+	if _, ok := seen[groupCI.Key()]; !ok {
+		t.Fatalf("group ci remote was not included in AllRemotes: %+v", groupCI)
+	}
+}
+
+func TestMergeRemoteClearsForgeSpecificFieldsWhenForgeChanges(t *testing.T) {
+	base := Remote{
+		Owner:       "alcxyz",
+		Forge:       "forgejo",
+		InstanceURL: "https://git.alc.xyz",
+		TokenFile:   "/tmp/forgejo-token",
+		CloneProto:  "ssh",
+		SSHHost:     "ssh-git.alc.xyz",
+	}
+
+	got := mergeRemote(base, Remote{Forge: "github"})
+	if got.EffectiveForge() != "github" {
+		t.Fatalf("expected github remote, got %+v", got)
+	}
+	if got.InstanceURL != "" || got.TokenFile != "" || got.CloneProto != "" || got.SSHHost != "" {
+		t.Fatalf("forge-specific fields should be cleared when forge changes: %+v", got)
+	}
+}
+
 // ── Load — legacy migration ───────────────────────────────────────────────
 
 func TestLoad_LegacyFlatConfig(t *testing.T) {

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -644,14 +644,44 @@ func RenderErrors(errs []string) string {
 	return b.String()
 }
 
-// RenderAuthError renders a prominent banner when gh is not authenticated.
-func RenderAuthError() string {
-	return "\n" +
-		DirtyStyle.Render("  ✗ GitHub authentication required") + "\n\n" +
-		DimStyle.Render("  Run the following command and then press r to retry:") + "\n\n" +
-		HeaderStyle.Render("    gh auth login") + "\n\n" +
-		DimStyle.Render("  If your org uses SAML SSO, also run:") + "\n" +
-		DimStyle.Render("    gh auth refresh -h github.com --scopes read:org") + "\n"
+// RenderAuthError renders a prominent banner for provider authentication
+// failures. kind is "github", "forgejo", "mixed", or "unknown".
+func RenderAuthError(kind string, errs []string) string {
+	var b strings.Builder
+	switch kind {
+	case "github":
+		b.WriteString("\n")
+		b.WriteString(DirtyStyle.Render("  ✗ GitHub authentication required") + "\n\n")
+		b.WriteString(DimStyle.Render("  Run the following command and then press r to retry:") + "\n\n")
+		b.WriteString(HeaderStyle.Render("    gh auth login") + "\n\n")
+		b.WriteString(DimStyle.Render("  If your org uses SAML SSO, also run:") + "\n")
+		b.WriteString(DimStyle.Render("    gh auth refresh -h github.com --scopes read:org") + "\n")
+	case "forgejo":
+		b.WriteString("\n")
+		b.WriteString(DirtyStyle.Render("  ✗ Forgejo authentication required") + "\n\n")
+		b.WriteString(DimStyle.Render("  Check the profile token_file, token permissions, and instance_url, then press r to retry.") + "\n")
+	case "mixed":
+		b.WriteString("\n")
+		b.WriteString(DirtyStyle.Render("  ✗ Multiple forge authentications failed") + "\n\n")
+		b.WriteString(DimStyle.Render("  Check GitHub login and Forgejo token_file settings, then press r to retry.") + "\n\n")
+		b.WriteString(HeaderStyle.Render("    gh auth login") + "\n")
+	default:
+		b.WriteString("\n")
+		b.WriteString(DirtyStyle.Render("  ✗ Forge authentication required") + "\n\n")
+		b.WriteString(DimStyle.Render("  Check the provider credentials in your config, then press r to retry.") + "\n")
+	}
+	if len(errs) > 0 {
+		b.WriteString("\n")
+		b.WriteString(DimStyle.Render("  Recent errors:") + "\n")
+		limit := len(errs)
+		if limit > 4 {
+			limit = 4
+		}
+		for _, e := range errs[:limit] {
+			b.WriteString(DimStyle.Render("  • "+e) + "\n")
+		}
+	}
+	return b.String()
 }
 
 // ── Issue row ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- include group-level remote overrides when constructing forge providers
- clear stale forge-specific fields when a remote switches forge families
- label load errors with the resolved forge provider
- show GitHub, Forgejo, mixed, or generic auth guidance instead of always showing gh auth login
- keep partial tab data visible when only some repos fail auth

## Validation
- gofmt
- go test ./...
- go build ./...
- go vet ./...