### PR TITLE
docs: define split-host integration workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,32 @@ go vet ./...
 
 ## Making changes
 
-1. Fork the repo and create a branch from `dev`
+1. Create a branch from `dev`
 2. Make your changes
 3. Add or update tests as needed
 4. Run `go test ./...` and `go vet ./...`
-5. Open a pull request against `dev`
+5. Push `dev` or your feature branch to GitHub when PR checks are needed
+6. Open a pull request against `main` on GitHub
 
 CI runs build, vet, and tests. All checks must pass before merging.
+
+## Split-host workflow
+
+Grove is Forgejo-primary for code hosting but GitHub-fronted for PRs, CI, releases, and distribution. GitHub is therefore the integration authority for `main`.
+
+Do not merge the same `dev -> main` change on both GitHub and Forgejo. Merge once on GitHub, then fast-forward Forgejo to the exact GitHub `main` commit:
+
+```bash
+git fetch github main dev --tags
+git fetch origin main dev --tags
+git switch dev
+git merge --ff-only github/main
+git push origin github/main:main
+git push origin dev
+git push github dev
+```
+
+If any fast-forward step is rejected, stop and inspect the divergence before doing anything else.
 
 ## Commit messages
 
@@ -64,12 +83,13 @@ Releases are automated via [GoReleaser](https://goreleaser.com/) and GitHub Acti
 To cut a release:
 
 1. Bump the `VERSION` file on `dev`
-2. Merge `dev` into `main`
+2. Open and merge the GitHub PR from `dev` to `main`
 3. CI automatically creates the git tag and runs GoReleaser
+4. Fast-forward the Forgejo mirror after GitHub `main` is green
 
 This builds binaries for linux/darwin x amd64/arm64, creates a GitHub release with changelog, updates the [Homebrew tap](https://github.com/alcxyz/homebrew-tap), and publishes to the [AUR](https://aur.archlinux.org/packages/grove-tui-bin) (`grove-tui-bin`).
 
-The `release.yml` workflow also exists as a fallback for manually re-triggering a release by pushing a `v*.*.*` tag.
+The old `release.yml` tag-triggered fallback was removed. `.github/workflows/ci.yml` is the release pipeline.
 
 ### Version numbering
 

--- a/README.md
+++ b/README.md
@@ -386,9 +386,13 @@ Existing repos (detected by the presence of a `.git` directory) are skipped. Up 
 Releases are automated. To publish a new version:
 
 1. Bump the `VERSION` file
-2. Merge to `main`
+2. Open and merge the GitHub PR from `dev` to `main`
+3. Wait for GitHub `main` CI to finish
+4. Fast-forward the Forgejo mirror to the exact GitHub `main` commit
 
 CI runs tests, creates a git tag from `VERSION`, and triggers goreleaser which builds binaries and publishes to GitHub Releases, Homebrew, and AUR.
+
+Grove is a split-host repo: Forgejo is the primary code host, while GitHub remains the integration authority for PRs, CI, releases, and distribution. Do not merge the same `dev -> main` change on both hosts. See [ADR-011](docs/adr/ADR-011-split-host-integration-authority.md).
 
 ## License
 

--- a/docs/adr/ADR-008-release-pipeline-structure.md
+++ b/docs/adr/ADR-008-release-pipeline-structure.md
@@ -20,6 +20,8 @@ The CI pipeline is structured as three sequential jobs:
 
 All three projects (grove, canopy, paperflow) use this same structure. The `release.yml` fallback workflow (triggered by manual tag push) is removed — `ci.yml` handles everything.
 
+For split-host repositories that are still GitHub-fronted for PRs, CI, releases, or distribution, GitHub is the integration authority for `main`. Merge `dev -> main` once on GitHub, let GitHub Actions run the release pipeline, then fast-forward the Forgejo mirror to the exact GitHub `main` commit. Do not open a second Forgejo PR for the same integration; that creates a duplicate merge commit for the same tree. See ADR-011.
+
 ## Alternatives Considered
 
 **Monolithic release job with inline Nix step**: simpler YAML, but Nix installation adds ~60s to every release even when the hash hasn't changed. A failure in vendorHash computation blocks the binary release. Rejected because distribution channels should be independent.
@@ -37,3 +39,4 @@ All three projects (grove, canopy, paperflow) use this same structure. The `rele
 - The pipeline is identical across all Go projects, reducing maintenance.
 - CI requires the `DeterminateSystems/nix-installer-action` in the Nix job, adding ~30s of setup time.
 - If the Nix job fails for reasons other than vendorHash (e.g., nixpkgs breakage), it surfaces as a separate failure that doesn't affect the release.
+- GitHub-fronted split-host repos keep one release source of truth: GitHub `main`.

--- a/docs/adr/ADR-009-split-remote-concerns.md
+++ b/docs/adr/ADR-009-split-remote-concerns.md
@@ -23,6 +23,8 @@ Treating the entire profile as one remote forces bad compromises:
 
 ADR-003 remote profiles are out of scope here. This is about already-cloned local repos whose remote concerns differ.
 
+Operationally, split concerns do not mean the same change should be integrated on every configured forge. ADR-011 defines the integration authority rule: one host creates the `main` merge commit, and any other host is updated by fast-forward mirror.
+
 ## Decision
 
 Split remote configuration into three concerns:
@@ -75,6 +77,7 @@ This keeps the common case compact while allowing directory-wide exceptions and 
 - cache invalidation must include concern-specific remote config, not just owner names and prefixes
 - API calls and browser URLs can target a remote repo name that differs from the local checkout directory
 - SSH clone URLs no longer have to guess the SSH host from `instance_url`
+- A repo with split concerns still needs one integration authority for `main`; the configured code, social, and CI remotes are data sources, not instructions to create PR merges on every forge
 
 ## Alternatives Considered
 

--- a/docs/adr/ADR-011-split-host-integration-authority.md
+++ b/docs/adr/ADR-011-split-host-integration-authority.md
@@ -1,0 +1,70 @@
+# ADR-011: Split-host integration authority
+
+**Status:** Accepted
+**Date:** 2026-05-03
+**Applies to:** repository workflow, release workflow, split remote concern configuration
+
+## Context
+
+ADR-009 allows one local repo to use different forges for code, social data, and CI. That matches the current migration state: Forgejo is the primary git host for most code, while a smaller set of repositories still uses GitHub for PRs, issues, CI, GitHub Releases, Homebrew, AUR, or GitHub Pages.
+
+This split creates a workflow trap. If the same `dev -> main` change is merged once on GitHub and again on Forgejo, each forge creates a different merge commit for the same tree. The resulting history is functionally equivalent but operationally messy:
+
+- both hosts show separate PRs for one integration
+- `main` briefly points at different commits on different hosts
+- CI can run more than once for the same effective change
+- release automation becomes harder to reason about
+- subsequent mirroring requires manual cleanup
+
+## Decision
+
+Each repository has exactly one **integration authority** for `main`.
+
+For GitHub-fronted repositories, GitHub is the integration authority. This includes repositories where PR review, issues, CI, releases, GitHub Pages, or distribution automation still live on GitHub. These repositories may still use Forgejo as the primary code remote for day-to-day pushes, but `main` is integrated on GitHub because GitHub owns the checks and release side effects.
+
+For Forgejo-first repositories, Forgejo is the integration authority.
+
+The non-authoritative host is mirror-only for `main` and `dev`:
+
+- push working branches such as `dev` to both hosts when needed for visibility or PR checks
+- open and merge the `dev -> main` PR only on the integration authority
+- after the authoritative merge, fetch that `main`
+- fast-forward the mirror host's `main` to the exact authoritative commit
+- fast-forward `dev` to the same commit on both hosts when the repo uses long-lived `dev`
+- do not open a second PR on the mirror host for the same integration
+- do not force-push except as an explicit break-glass repair after inspecting divergence
+
+For a GitHub-fronted repository, the normal sync after a GitHub PR merge is:
+
+```sh
+git fetch github main dev --tags
+git fetch origin main dev --tags
+git switch dev
+git merge --ff-only github/main
+git push origin github/main:main
+git push origin dev
+git push github dev
+```
+
+For a Forgejo-first repository with GitHub as a mirror, swap `origin` and `github` in the authoritative and mirror roles.
+
+If any fast-forward push or merge is rejected, stop and inspect the divergence. A rejection means the mirror host has commits that are not descendants of the authoritative integration commit, and blindly continuing would recreate the duplicate-merge problem this ADR avoids.
+
+## Consequences
+
+- There is one PR record per integration, on the host that owns review and checks.
+- There is one merge commit per integration.
+- Release automation is triggered from the authoritative host only.
+- Mirror hosts remain useful for browsing and cloning, but they do not create integration commits.
+- Grove's split remote concerns describe where data comes from; they do not imply that every configured forge should receive its own PR merge.
+- Automation should prefer fast-forward mirroring commands over API-created mirror PRs.
+
+## Alternatives Considered
+
+**Open matching PRs on both hosts** - rejected because it creates separate merge commits for the same tree and makes release state harder to reason about.
+
+**Force-push the mirror to match the authority** - rejected for normal workflow because it hides divergence. Fast-forward-only updates are safer and surface real conflicts.
+
+**Make Forgejo authoritative for all code even when GitHub owns CI and releases** - rejected for GitHub-fronted repositories because the release and distribution side effects currently run from GitHub `main`.
+
+**Move every repository fully to Forgejo immediately** - desirable long term for Forgejo-first projects, but not true for GitHub Pages, forks, and projects whose issues, PRs, pipelines, or distribution channels intentionally remain on GitHub.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@
 | [ADR-008](ADR-008-release-pipeline-structure.md) | Release pipeline structure | CI, Nix |
 | [ADR-009](ADR-009-split-remote-concerns.md) | Split remote concerns per profile, group, and repo | config, app, clone |
 | [ADR-010](ADR-010-azure-devops-provider.md) | Azure DevOps provider support | forge, config, app, clone |
+| [ADR-011](ADR-011-split-host-integration-authority.md) | Split-host integration authority | workflow, release |


### PR DESCRIPTION
## Summary\n\n- add ADR-011 defining one integration authority for split-host repos\n- update release docs and CONTRIBUTING to avoid double-merging GitHub and Forgejo PRs\n- link the workflow to the split remote concerns ADR\n\n#32 tracks automation for this workflow.\n\n## Tests\n\n- git diff --check