### PR TITLE
docs: document mirror branch protection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ git push github dev
 
 If any fast-forward step is rejected, stop and inspect the divergence before doing anything else.
 
+Forgejo `main` is still protected, but the branch protection must allow the maintainer identity to push-whitelisted fast-forward mirrors. A protected-branch push rejection is a repo setting problem, not a reason to create a second Forgejo PR for the same change.
+
 ## Commit messages
 
 Use conventional-ish prefixes to keep history scannable:

--- a/docs/adr/ADR-011-split-host-integration-authority.md
+++ b/docs/adr/ADR-011-split-host-integration-authority.md
@@ -34,6 +34,8 @@ The non-authoritative host is mirror-only for `main` and `dev`:
 - do not open a second PR on the mirror host for the same integration
 - do not force-push except as an explicit break-glass repair after inspecting divergence
 
+Mirror branch protection must allow the mirroring identity to push to protected `main` without force. For Forgejo, keep `main` protected, but enable a push whitelist for the maintainer or deploy identity that performs fast-forward mirrors. If branch protection rejects the fast-forward push, fix the protection rule before falling back to a mirror PR.
+
 For a GitHub-fronted repository, the normal sync after a GitHub PR merge is:
 
 ```sh
@@ -56,6 +58,7 @@ If any fast-forward push or merge is rejected, stop and inspect the divergence. 
 - There is one merge commit per integration.
 - Release automation is triggered from the authoritative host only.
 - Mirror hosts remain useful for browsing and cloning, but they do not create integration commits.
+- Mirror branch protection has to allow controlled fast-forward pushes.
 - Grove's split remote concerns describe where data comes from; they do not imply that every configured forge should receive its own PR merge.
 - Automation should prefer fast-forward mirroring commands over API-created mirror PRs.
 


### PR DESCRIPTION
## Summary\n\n- document that mirror branch protection must allow push-whitelisted fast-forward mirrors\n- clarify that protected-branch rejection is a repo setting issue, not a reason to create a second mirror PR\n\n#32 tracks automation for this workflow.\n\n## Tests\n\n- git diff --check