### PR TITLE
[codex] clarify Nix release branch contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Validate release version
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          VERSION="$(cat VERSION)"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::main releases require VERSION to be plain semver, got $VERSION"
+            exit 1
+          fi
+
       - name: GoReleaser snapshot
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,15 @@ Use conventional-ish prefixes to keep history scannable:
 
 Releases are automated via [GoReleaser](https://goreleaser.com/) and GitHub Actions. The `VERSION` file is the single source of truth.
 
+`main` and release tags use plain `x.y.z` versions. Long-lived development branches use non-release versions such as `0.9.2-dev`, so branch-based Nix builds and `grove --version` do not present themselves as released builds.
+
 To cut a release:
 
-1. Bump the `VERSION` file on `dev`
+1. Bump the `VERSION` file on `dev` to a plain release version like `0.9.2`
 2. Open and merge the GitHub PR from `dev` to `main`
 3. CI automatically creates the git tag and runs GoReleaser
 4. Fast-forward the Forgejo mirror after GitHub `main` is green
+5. Bump `dev` to the next non-release version like `0.9.3-dev`
 
 This builds binaries for linux/darwin x amd64/arm64, creates a GitHub release with changelog, updates the [Homebrew tap](https://github.com/alcxyz/homebrew-tap), and publishes to the [AUR](https://aur.archlinux.org/packages/grove-tui-bin) (`grove-tui-bin`).
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,22 @@ brew install grove
 ### Nix
 
 ```sh
-nix profile install github:alcxyz/grove
+nix profile install github:alcxyz/grove/main
 ```
 
 Or in a flake:
 
 ```nix
-inputs.grove.url = "github:alcxyz/grove";
+inputs.grove.url = "github:alcxyz/grove/main";
 ```
+
+For an unreleased development build, point at the branch explicitly:
+
+```sh
+nix profile install github:alcxyz/grove/dev
+```
+
+Development branch builds report a non-release version such as `0.9.2-dev`.
 
 ### AUR (Arch Linux)
 
@@ -385,10 +393,11 @@ Existing repos (detected by the presence of a `.git` directory) are skipped. Up 
 
 Releases are automated. To publish a new version:
 
-1. Bump the `VERSION` file
+1. Bump the `VERSION` file on `dev` to a plain release version like `0.9.2`
 2. Open and merge the GitHub PR from `dev` to `main`
 3. Wait for GitHub `main` CI to finish
 4. Fast-forward the Forgejo mirror to the exact GitHub `main` commit
+5. Bump `dev` to the next non-release version like `0.9.3-dev`
 
 CI runs tests, creates a git tag from `VERSION`, and triggers goreleaser which builds binaries and publishes to GitHub Releases, Homebrew, and AUR.
 


### PR DESCRIPTION
## Summary

- Point Nix install and flake examples at `github:alcxyz/grove/main` now that `main` is the public release branch.
- Document `dev` as an explicit unreleased build that reports a non-release version such as `0.9.2-dev`.
- Add a CI guard so pushes to `main` only auto-release when `VERSION` is plain semver.

## Why

The repository default branch had been `dev`, so unqualified Nix flake installs could build unreleased code while the binary still reported the released `VERSION`. This PR makes the release branch explicit for users and prevents `main` from auto-tagging a development version.

## Validation

- `go test ./...`
- `nix eval .#packages.aarch64-darwin.grove.version --raw` -> `0.9.1`